### PR TITLE
chore: sync main into develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -1,0 +1,10 @@
+name: Auto Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  conflicts:
+    uses: preprio/.github-workflows/.github/workflows/code-conflicts.yml@main
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Laravel package is a provider for the Prepr REST API.
 
 You can install the Provider as a composer package.
 
-For Laravel v10x
+For Laravel v10x, v11x and Laravel v12x
 
 ```bash
 composer require preprio/laravel-rest-sdk:"^4.0"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Laravel package is a provider for the Prepr REST API.
 ## Basics
 
 - The SDK on [GitHub](https://github.com/preprio/laravel-rest-sdk)  
-- Compatible with Laravel `v5x`, `v6x`, `v7x`, `v8x`, `v9x`, `v10x`.
+- Compatible with Laravel `v5x`, `v6x`, `v7x`, `v8x`, `v9x`, `v10x`, `v11x`, `v12x`.
 - Requires `GuzzleHttp 7.3.X`, and for version 3.0 and above PHP 8.x is required.
 
 ## Installation


### PR DESCRIPTION
This PR syncs `main` into `develop` because `main` is ahead.

- Detected ahead commits: 10
