### PR TITLE
chore: sync main into develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ For Laravel v9x
 composer require preprio/laravel-rest-sdk:"^2.0"
 ```
 
-For Laravel v8x
-
-```bash
-composer require preprio/laravel-rest-sdk:"^1.3"
-```
-
 ### Publish config
 
 Publish `prepr.php` config

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This Laravel package is a provider for the Prepr REST API.
 ## Basics
 
 - The SDK on [GitHub](https://github.com/preprio/laravel-rest-sdk)  
-- Compatible with Laravel `v5x`, `v6x`, `v7x`, `v8x`, `v9x`, `v10x`, `v11x`, `v12x`.
+- Compatible with Laravel `v8x`, `v9x`, `v10x`, `v11x`, `v12x`.
 - Requires `GuzzleHttp 7.3.X`, and for version 3.0 and above PHP 8.x is required.
 
 ## Installation
@@ -28,12 +28,6 @@ For Laravel v8x
 
 ```bash
 composer require preprio/laravel-rest-sdk:"^1.3"
-```
-
-Other versions
-
-```bash
-composer require preprio/laravel-rest-sdk:"1.1"
 ```
 
 ### Publish config


### PR DESCRIPTION
This PR syncs `main` into `develop` because `main` is ahead with changes.

- Detected ahead commits: 4
